### PR TITLE
Remove conflicting root route in Next.js app

### DIFF
--- a/src/app/route.ts
+++ b/src/app/route.ts
@@ -1,4 +1,0 @@
-// REMOVED: This file conflicted with src/app/page.tsx and should be deleted.
-// Left as a marker temporarily. Do not use as route.
-
-export const __removed = true;


### PR DESCRIPTION
## Summary
- delete `src/app/route.ts` so Next.js no longer finds both a `page` and a `route` at the root path

## Testing
- `npm run build` *(fails: Module not found: Can't resolve 'papaparse')*


------
https://chatgpt.com/codex/tasks/task_e_68b5bd7e5868832abbf0c8acb862c8a2